### PR TITLE
adding postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start:dev": "lite-server",
     "build": "webpack",
     "build:min": "webpack  --optimize-minimize",
-    "clean": "rm -r dist"
+    "clean": "rm -r dist",
+    "postinstall": "webpack --optimize-minimize"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I think we need this in the package.json file to get Heroku to build the app properly (the `/dist` directory). Otherwise, it's just relying on potentially out of date files in the repository - see https://devcenter.heroku.com/articles/node-best-practices#hook-things-up

If it works, we can remove everything from `/dist` in another commit.